### PR TITLE
Implement `getName()` to `ConnectionInterface::class`.

### DIFF
--- a/src/ConnectionPDO.php
+++ b/src/ConnectionPDO.php
@@ -68,6 +68,11 @@ final class ConnectionPDO extends AbstractConnectionPDO
         return $this->quoter;
     }
 
+    public function getName(): string
+    {
+        return $this->getDriver()->getName();
+    }
+
     public function getSchema(): SchemaInterface
     {
         if ($this->schema === null) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
