### PR TITLE
Support for MySQL ANSI/ANSI_QUOTES modes

### DIFF
--- a/.github/workflows/build_ansi_mode.yml
+++ b/.github/workflows/build_ansi_mode.yml
@@ -50,11 +50,11 @@ jobs:
           MYSQL_DATABASE: yiitest
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: --name=mysql_ansi --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
       - name: Change mysql sql_mode
-        run: docker exec mysql mysql -u root -e "SET GLOBAL sql_mode = 'ANSI';"
+        run: docker exec mysql_ansi mysql -u root -e "SET GLOBAL sql_mode = 'ANSI';"
       - name: Checkout.
         uses: actions/checkout@v3
 

--- a/.github/workflows/build_ansi_mode.yml
+++ b/.github/workflows/build_ansi_mode.yml
@@ -1,0 +1,80 @@
+on:
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.gitignore'
+      - '.gitattributes'
+      - 'infection.json.dist'
+      - 'psalm.xml'
+
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.gitignore'
+      - '.gitattributes'
+      - 'infection.json.dist'
+      - 'psalm.xml'
+
+name: build
+
+jobs:
+  tests:
+    name: PHP ${{ matrix.php }}-${{ matrix.mysql }}
+
+    env:
+      extensions: pdo, pdo_mysql
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+
+        php:
+          - 8.0
+
+        mysql:
+          - mysql:5.7
+
+    services:
+      mysql:
+        image: ${{ matrix.mysql }}
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: true
+          MYSQL_PASSWORD: ''
+          MYSQL_DATABASE: yiitest
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 --sql-mode=ANSI
+
+    steps:
+      - name: Checkout.
+        uses: actions/checkout@v3
+
+      - name: Install PHP with extensions.
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: ${{ env.extensions }}
+          ini-values: date.timezone='UTC'
+          coverage: pcov
+
+      - name: Update composer.
+        run: composer self-update
+
+      - name: Install dependencies with composer.
+        run: composer update --no-interaction --no-progress --optimize-autoloader --ansi
+
+      - name: Run tests with phpunit with code coverage.
+        run: vendor/bin/phpunit --coverage-clover=coverage.xml --colors=always
+
+      - name: Upload coverage to Codecov.
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml

--- a/.github/workflows/build_ansi_mode.yml
+++ b/.github/workflows/build_ansi_mode.yml
@@ -19,7 +19,7 @@ on:
       - 'infection.json.dist'
       - 'psalm.xml'
 
-name: build_ans_mode
+name: build_ansi_mode
 
 jobs:
   tests:
@@ -50,7 +50,7 @@ jobs:
           MYSQL_DATABASE: yiitest
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 --sql-mode=ANSI
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
       - name: Change mysql sql_mode

--- a/.github/workflows/build_ansi_mode.yml
+++ b/.github/workflows/build_ansi_mode.yml
@@ -39,7 +39,7 @@ jobs:
           - 8.0
 
         mysql:
-          - mysql:5.7
+          - mysql:8.0.29
 
     services:
       mysql:

--- a/.github/workflows/build_ansi_mode.yml
+++ b/.github/workflows/build_ansi_mode.yml
@@ -19,7 +19,7 @@ on:
       - 'infection.json.dist'
       - 'psalm.xml'
 
-name: build
+name: build_ans_mode
 
 jobs:
   tests:
@@ -53,6 +53,8 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3 --sql-mode=ANSI
 
     steps:
+      - name: Change mysql sql_mode
+        run: docker exec mysql mysql -u root -e "SET GLOBAL sql_mode = 'ANSI';"
       - name: Checkout.
         uses: actions/checkout@v3
 

--- a/src/DDLQueryBuilder.php
+++ b/src/DDLQueryBuilder.php
@@ -202,10 +202,10 @@ final class DDLQueryBuilder extends AbstractDDLQueryBuilder
             return '';
         }
 
-        if (preg_match_all('/^\s*`(.*?)`\s+(.*?),?$/m', $sql, $matches)) {
-            foreach ($matches[1] as $i => $c) {
+        if (preg_match_all('/^\s*([`"])(.*?)\\1\s+(.*?),?$/m', $sql, $matches)) {
+            foreach ($matches[2] as $i => $c) {
                 if ($c === $column) {
-                    $result = $matches[2][$i];
+                    $result = $matches[3][$i];
                 }
             }
         }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -161,12 +161,12 @@ final class Schema extends AbstractSchema
 
         $uniqueIndexes = [];
 
-        $regexp = '/UNIQUE KEY\s+`(.+)`\s*\((`.+`)+\)/mi';
+        $regexp = '/UNIQUE KEY\s+[`"](.+)[`"]\s*\(([`"].+[`"])+\)/mi';
 
         if (preg_match_all($regexp, $sql, $matches, PREG_SET_ORDER)) {
             foreach ($matches as $match) {
                 $indexName = $match[1];
-                $indexColumns = array_map('trim', explode('`,`', trim($match[2], '`')));
+                $indexColumns = array_map('trim', preg_split('/[`"],[`"]/', trim($match[2], '`"')));
                 $uniqueIndexes[$indexName] = $indexColumns;
             }
         }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -13,10 +13,8 @@ use Yiisoft\Db\Expression\ExpressionInterface;
 use Yiisoft\Db\Mysql\Tests\Support\TestTrait;
 use Yiisoft\Db\Query\Query;
 use Yiisoft\Db\Query\QueryInterface;
-use Yiisoft\Db\Schema\SchemaInterface;
 use Yiisoft\Db\Tests\Common\CommonQueryBuilderTest;
 
-use Yiisoft\Db\Tests\Provider\ColumnTypes;
 use function str_contains;
 use function version_compare;
 
@@ -572,40 +570,4 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
     ): void {
         parent::testUpsertExecute($table, $insertColumns, $updateColumns);
     }
-
-    public function testCreateTableWithGetColumnTypes(): void
-    {
-        $db = $this->getConnection(true);
-
-        $qb = $db->getQueryBuilder();
-
-        if ($db->getTableSchema('column_type_table', true) !== null) {
-            $db->createCommand($qb->dropTable('column_type_table'))->execute();
-        }
-
-        $columnTypes = (new ColumnTypes($db))->getColumnTypes();
-        $columns = [];
-        $i = 0;
-
-        foreach ($columnTypes as [$column, $builder, $expected]) {
-            if (
-                !(
-                    strncmp($column, SchemaInterface::TYPE_PK, 2) === 0 ||
-                    strncmp($column, SchemaInterface::TYPE_UPK, 3) === 0 ||
-                    strncmp($column, SchemaInterface::TYPE_BIGPK, 5) === 0 ||
-                    strncmp($column, SchemaInterface::TYPE_UBIGPK, 6) === 0 ||
-                    str_starts_with(substr($column, -5), 'FIRST')
-                )
-            ) {
-                $columns['col' . ++$i] = str_replace('CHECK (value', 'CHECK ([[col' . $i . ']]', $column);
-            }
-        }
-
-        $db->createCommand($qb->createTable('column_type_table', $columns))->execute();
-
-        $this->assertNotEmpty($db->getTableSchema('column_type_table', true));
-
-        $db->close();
-    }
-
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -587,9 +587,6 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
         $columns = [];
         $i = 0;
 
-        echo $db->createCommand('SELECT @@sql_mode;')->queryScalar();die;
-
-
         foreach ($columnTypes as [$column, $builder, $expected]) {
             if (
                 !(
@@ -604,7 +601,9 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
             }
         }
 
-        $db->createCommand($qb->createTable('column_type_table', $columns))->execute();
+        $command = $db->createCommand($qb->createTable('column_type_table', $columns));
+        echo $command->getRawSql();die;
+        $command->execute();
 
         $this->assertNotEmpty($db->getTableSchema('column_type_table', true));
 

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -518,7 +518,7 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
         $insertResult = $command->insertWithReturningPks('item', ['name' => '123', 'category_id' => 1]);
         $this->assertEquals(43, $insertResult['id']);
 
-        $command->delete('item',['>=','id', 6])->execute();
+        $command->delete('item', ['>=','id', 6])->execute();
         // And again change to max rows.
         $sql = <<<SQL
         SET @new_autoincrement_value := (SELECT MAX(`id`) + 1 FROM `item`);

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -601,9 +601,7 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
             }
         }
 
-        $command = $db->createCommand($qb->createTable('column_type_table', $columns));
-        echo $command->getRawSql();die;
-        $command->execute();
+        $db->createCommand($qb->createTable('column_type_table', $columns))->execute();
 
         $this->assertNotEmpty($db->getTableSchema('column_type_table', true));
 

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -13,8 +13,10 @@ use Yiisoft\Db\Expression\ExpressionInterface;
 use Yiisoft\Db\Mysql\Tests\Support\TestTrait;
 use Yiisoft\Db\Query\Query;
 use Yiisoft\Db\Query\QueryInterface;
+use Yiisoft\Db\Schema\SchemaInterface;
 use Yiisoft\Db\Tests\Common\CommonQueryBuilderTest;
 
+use Yiisoft\Db\Tests\Provider\ColumnTypes;
 use function str_contains;
 use function version_compare;
 
@@ -570,4 +572,43 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
     ): void {
         parent::testUpsertExecute($table, $insertColumns, $updateColumns);
     }
+
+    public function testCreateTableWithGetColumnTypes(): void
+    {
+        $db = $this->getConnection(true);
+
+        $qb = $db->getQueryBuilder();
+
+        if ($db->getTableSchema('column_type_table', true) !== null) {
+            $db->createCommand($qb->dropTable('column_type_table'))->execute();
+        }
+
+        $columnTypes = (new ColumnTypes($db))->getColumnTypes();
+        $columns = [];
+        $i = 0;
+
+        echo $db->createCommand('SELECT @@sql_mode;')->queryScalar();die;
+
+
+        foreach ($columnTypes as [$column, $builder, $expected]) {
+            if (
+                !(
+                    strncmp($column, SchemaInterface::TYPE_PK, 2) === 0 ||
+                    strncmp($column, SchemaInterface::TYPE_UPK, 3) === 0 ||
+                    strncmp($column, SchemaInterface::TYPE_BIGPK, 5) === 0 ||
+                    strncmp($column, SchemaInterface::TYPE_UBIGPK, 6) === 0 ||
+                    str_starts_with(substr($column, -5), 'FIRST')
+                )
+            ) {
+                $columns['col' . ++$i] = str_replace('CHECK (value', 'CHECK ([[col' . $i . ']]', $column);
+            }
+        }
+
+        $db->createCommand($qb->createTable('column_type_table', $columns))->execute();
+
+        $this->assertNotEmpty($db->getTableSchema('column_type_table', true));
+
+        $db->close();
+    }
+
 }


### PR DESCRIPTION
https://github.com/yiisoft/yii2/pull/18500

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ✔️
| Breaks BC?    | ❌

This PR adds support for MySQL’s ANSI and ANSI_QUOTES modes, by checking for " characters in addition to ` whenever parsing the results of a SHOW CREATE TABLE command.

ANSI_QUOTES is enabled by default on DigitalOcean for MySQL 8, so it would be great to get this pulled in.

