### PR TITLE
ErrorException in \yii\db\mysql\Schema::loadColumnSchema on PHP 8.1

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -516,8 +516,9 @@ final class Schema extends AbstractSchema
              *
              * See details here: https://mariadb.com/kb/en/library/now/#description
              */
-            if (
-                ($column->getType() === 'timestamp' || $column->getType() === 'datetime')
+            if (true
+//                isset($info['default'])
+                && ($column->getType() === 'timestamp' || $column->getType() === 'datetime')
                 && preg_match('/^current_timestamp(?:\((\d*)\))?$/i', (string) $info['default'], $matches)
             ) {
                 $column->defaultValue(new Expression('CURRENT_TIMESTAMP' . (!empty($matches[1])

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -516,8 +516,8 @@ final class Schema extends AbstractSchema
              *
              * See details here: https://mariadb.com/kb/en/library/now/#description
              */
-            if (true
-//                isset($info['default'])
+            if (
+                isset($info['default'])
                 && ($column->getType() === 'timestamp' || $column->getType() === 'datetime')
                 && preg_match('/^current_timestamp(?:\((\d*)\))?$/i', (string) $info['default'], $matches)
             ) {

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -517,8 +517,7 @@ final class Schema extends AbstractSchema
              * See details here: https://mariadb.com/kb/en/library/now/#description
              */
             if (
-                isset($info['default'])
-                && ($column->getType() === 'timestamp' || $column->getType() === 'datetime')
+                ($column->getType() === 'timestamp' || $column->getType() === 'datetime')
                 && preg_match('/^current_timestamp(?:\((\d*)\))?$/i', (string) $info['default'], $matches)
             ) {
                 $column->defaultValue(new Expression('CURRENT_TIMESTAMP' . (!empty($matches[1])

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -83,10 +83,10 @@ final class SchemaTest extends CommonSchemaTest
         $column = Assert::invokeMethod($schema, 'loadColumnSchema', [[
             'field' => 'emulated_MariaDB_field',
             'type' => 'timestamp',
-            'collation' => NULL,
+            'collation' => null,
             'null' => 'NO',
             'key' => '',
-            'default' => NULL,
+            'default' => null,
             'extra' => '',
             'privileges' => 'select,insert,update,references',
             'comment' => '',

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -69,6 +69,34 @@ final class SchemaTest extends CommonSchemaTest
     }
 
     /**
+     * When displayed in the INFORMATION_SCHEMA.COLUMNS table, a default CURRENT TIMESTAMP is provided
+     * as NULL.
+     *
+     * @see https://github.com/yiisoft/yii2/issues/19047
+     */
+    public function testAlternativeDisplayOfDefaultCurrentTimestampAsNullInMariaDB(): void
+    {
+        $db = $this->getConnection();
+
+        $schema = new Schema($db, DbHelper::getSchemaCache());
+
+        $column = Assert::invokeMethod($schema, 'loadColumnSchema', [[
+            'field' => 'emulated_MariaDB_field',
+            'type' => 'timestamp',
+            'collation' => NULL,
+            'null' => 'NO',
+            'key' => '',
+            'default' => NULL,
+            'extra' => '',
+            'privileges' => 'select,insert,update,references',
+            'comment' => '',
+        ]]);
+
+        $this->assertInstanceOf(ColumnSchema::class, $column);
+        $this->assertEquals(null, $column->getDefaultValue());
+    }
+
+    /**
      * @dataProvider \Yiisoft\Db\Mysql\Tests\Provider\SchemaProvider::columns()
      *
      * @throws Exception


### PR DESCRIPTION
https://github.com/yiisoft/yii2/pull/19211

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

