### PR TITLE
Fix default expression detection for MariaDB `date` and `time` columns

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -517,7 +517,7 @@ final class Schema extends AbstractSchema
              * See details here: https://mariadb.com/kb/en/library/now/#description
              */
             if (
-                ($column->getType() === 'timestamp' || $column->getType() === 'datetime')
+                in_array($column->getType(), ['timestamp', 'datetime', 'date', 'time'], true)
                 && preg_match('/^current_timestamp(?:\((\d*)\))?$/i', (string) $info['default'], $matches)
             ) {
                 $column->defaultValue(new Expression('CURRENT_TIMESTAMP' . (!empty($matches[1])


### PR DESCRIPTION
https://github.com/yiisoft/yii2/pull/19538

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌

