### PR TITLE
Remove `getCacheKey()` to `ConnectionInterface::class`.

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -9,15 +9,15 @@ use Throwable;
 use Yiisoft\Db\Constraint\Constraint;
 use Yiisoft\Db\Constraint\ForeignKeyConstraint;
 use Yiisoft\Db\Constraint\IndexConstraint;
+use Yiisoft\Db\Driver\PDO\PdoAbstractSchema;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\NotSupportedException;
 use Yiisoft\Db\Expression\Expression;
 use Yiisoft\Db\Helper\ArrayHelper;
-use Yiisoft\Db\Schema\AbstractSchema;
 use Yiisoft\Db\Schema\Builder\AbstractColumn;
-use Yiisoft\Db\Schema\ColumnSchemaInterface;
 use Yiisoft\Db\Schema\Builder\ColumnInterface;
+use Yiisoft\Db\Schema\ColumnSchemaInterface;
 use Yiisoft\Db\Schema\TableSchemaInterface;
 
 use function array_map;
@@ -92,7 +92,7 @@ use function trim;
  *   }
  * >
  */
-final class Schema extends AbstractSchema
+final class Schema extends PdoAbstractSchema
 {
     /**
      * @var array Mapping from physical column types (keys) to abstract column types (values).
@@ -413,7 +413,7 @@ final class Schema extends AbstractSchema
      */
     protected function getCacheKey(string $name): array
     {
-        return array_merge([self::class], $this->db->getCacheKey(), [$this->getRawTableName($name)]);
+        return array_merge([self::class], $this->generateCacheKey(), [$this->getRawTableName($name)]);
     }
 
     /**
@@ -425,7 +425,7 @@ final class Schema extends AbstractSchema
      */
     protected function getCacheTag(): string
     {
-        return md5(serialize(array_merge([self::class], $this->db->getCacheKey())));
+        return md5(serialize(array_merge([self::class], $this->generateCacheKey())));
     }
 
     /**

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -9,6 +9,7 @@ use Throwable;
 use Yiisoft\Db\Command\CommandInterface;
 use Yiisoft\Db\Connection\ConnectionInterface;
 use Yiisoft\Db\Constraint\Constraint;
+use Yiisoft\Db\Driver\PDO\ConnectionPDOInterface;
 use Yiisoft\Db\Exception\Exception;
 use Yiisoft\Db\Exception\InvalidConfigException;
 use Yiisoft\Db\Exception\NotSupportedException;
@@ -406,7 +407,7 @@ final class SchemaTest extends CommonSchemaTest
 
         $commandMock = $this->createMock(CommandInterface::class);
         $commandMock->method('queryAll')->willReturn([]);
-        $mockDb = $this->createMock(ConnectionInterface::class);
+        $mockDb = $this->createMock(ConnectionPDOInterface::class);
         $mockDb->method('getQuoter')->willReturn($db->getQuoter());
         $mockDb
             ->method('createCommand')
@@ -523,5 +524,16 @@ final class SchemaTest extends CommonSchemaTest
 
         $this->assertEquals($status, $selectedRow['status']);
         $this->assertEquals(true, $selectedRow['bool_col']);
+    }
+
+    public function testNotConnectionPDO(): void
+    {
+        $db = $this->createMock(ConnectionInterface::class);
+        $schema = new Schema($db, DbHelper::getSchemaCache());
+
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessage('Only PDO connections are supported.');
+
+        $schema->refreshTableSchema('customer');
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Issue | https://github.com/yiisoft/db/pull/650
