### PR TITLE
Possible Bug value typecast in ColumnSchema for JSON DB data type

### DIFF
--- a/src/ColumnSchema.php
+++ b/src/ColumnSchema.php
@@ -56,7 +56,7 @@ final class ColumnSchema extends AbstractColumnSchema
         }
 
         if ($this->getType() === SchemaInterface::TYPE_JSON) {
-            return json_decode((string) $value, true, 512, JSON_THROW_ON_ERROR);
+            return is_array($value) ? $value : json_decode((string) $value, true, 512, JSON_THROW_ON_ERROR);
         }
 
         return parent::phpTypecast($value);


### PR DESCRIPTION
PHP Warning — Yiisoft\ErrorHandler\Exception\ErrorException Array to string conversion

i think this occurs when phpTypecast call more than one time. 
- 1st call: Convert string (direct value from DB) to array
- 2nd call: Convert array to array

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | 