### PR TITLE
Remove `QueryBuilder::getColumnType()` child method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 1.0.2 under development
 
-- no changes in this release.
+- Chg #297: Remove `QueryBuilder::getColumnType()` child method as legacy code (@Tigrov)
 
 ## 1.0.1 July 24, 2023
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yiisoft\Db\Mysql;
 
 use Yiisoft\Db\QueryBuilder\AbstractQueryBuilder;
-use Yiisoft\Db\Schema\Builder\ColumnInterface;
 use Yiisoft\Db\Schema\QuoterInterface;
 use Yiisoft\Db\Schema\SchemaInterface;
 

--- a/src/QueryBuilder.php
+++ b/src/QueryBuilder.php
@@ -53,14 +53,4 @@ final class QueryBuilder extends AbstractQueryBuilder
         $dqlBuilder = new DQLQueryBuilder($this, $quoter);
         parent::__construct($quoter, $schema, $ddlBuilder, $dmlBuilder, $dqlBuilder);
     }
-
-    public function getColumnType(ColumnInterface|string $type): string
-    {
-        if ($type instanceof ColumnInterface && $type->getType() === SchemaInterface::TYPE_JSON) {
-            $type->check('[[{name}]] is null or json_valid([[{name}]])');
-            $type = SchemaInterface::TYPE_JSON;
-        }
-
-        return parent::getColumnType($type);
-    }
 }


### PR DESCRIPTION
Remove legacy code

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
