### PR TITLE
Allow scalar values for `Query::select()`

### DIFF
--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -639,4 +639,10 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
     ): void {
         parent::testUpsertExecute($table, $insertColumns, $updateColumns);
     }
+
+    /** @dataProvider \Yiisoft\Db\Mysql\Tests\Provider\QueryBuilderProvider::selectScalar */
+    public function testSelectScalar(array|bool|float|int $columns, string $expected): void
+    {
+        parent::testSelectScalar($columns, $expected);
+    }
 }

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -641,7 +641,7 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
     }
 
     /** @dataProvider \Yiisoft\Db\Mysql\Tests\Provider\QueryBuilderProvider::selectScalar */
-    public function testSelectScalar(array|bool|float|int $columns, string $expected): void
+    public function testSelectScalar(array|bool|float|int|string $columns, string $expected): void
     {
         parent::testSelectScalar($columns, $expected);
     }


### PR DESCRIPTION
Update tests according main PR yiisoft/db#816