### PR TITLE
Replace call of `SchemaInterface::getRawTableName()` to `QuoterInterface::getRawTableName()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Enh #320: Minor refactoring of `DDLQueryBuilder::getColumnDefinition()` method (@Tigrov)
 - Bug #320: Change visibility of `DDLQueryBuilder::getColumnDefinition()` method to `private` (@Tigrov)
 - Enh #321: Implement `SqlParser` and `ExpressionBuilder` driver classes (@Tigrov)
+- Chg #339: Replace call of `SchemaInterface::getRawTableName()` to `QuoterInterface::getRawTableName()` (@Tigrov)
 
 ## 1.2.0 March 21, 2024
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -415,7 +415,7 @@ final class Schema extends AbstractPdoSchema
      */
     protected function getCacheKey(string $name): array
     {
-        return array_merge([self::class], $this->generateCacheKey(), [$this->getRawTableName($name)]);
+        return array_merge([self::class], $this->generateCacheKey(), [$this->db->getQuoter()->getRawTableName($name)]);
     }
 
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | yiisoft/db#767