### PR TITLE
Add `$ifExists` and `$cascade` to `dropTable()` methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - New #374: Add `IndexType` and `IndexMethod` classes (@Tigrov)
 - Enh #376: Move `JsonExpressionBuilder` and JSON type tests to `yiisoft/db` package (@Tigrov)
 - Bug #377: Explicitly mark nullable parameters (@vjik)
+- New #379: Add parameters `$ifExists` and `$cascade` to `CommandInterface::dropTable()` and
+  `DDLQueryBuilderInterface::dropTable()` methods (@vjik)
 
 ## 1.2.0 March 21, 2024
 

--- a/src/DDLQueryBuilder.php
+++ b/src/DDLQueryBuilder.php
@@ -189,7 +189,7 @@ final class DDLQueryBuilder extends AbstractDDLQueryBuilder
     }
 
     /**
-     * @throws NotSupportedException SQLite doesn't support cascade drop table.
+     * @throws NotSupportedException MySQL doesn't support cascade drop table.
      */
     public function dropTable(string $table, bool $ifExists = false, bool $cascade = false): string
     {

--- a/src/DDLQueryBuilder.php
+++ b/src/DDLQueryBuilder.php
@@ -187,4 +187,15 @@ final class DDLQueryBuilder extends AbstractDDLQueryBuilder
 
         return $matches[2];
     }
+
+    /**
+     * @throws NotSupportedException SQLite doesn't support cascade drop table.
+     */
+    public function dropTable(string $table, bool $ifExists = false, bool $cascade = false): string
+    {
+        if ($cascade) {
+            throw new NotSupportedException('MySQL doesn\'t support cascade drop table.');
+        }
+        return parent::dropTable($table, $ifExists, false);
+    }
 }

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -93,6 +93,15 @@ final class CommandTest extends CommonCommandTest
         parent::testDropDefaultValue();
     }
 
+    public function testDropTableCascade(): void
+    {
+        $command = $this->getConnection()->createCommand();
+
+        $this->expectException(NotSupportedException::class);
+        $this->expectExceptionMessage('SQLite doesn\'t support cascade drop table.');
+        $command->dropTable('{{table}}', cascade: true);
+    }
+
     /**
      * @dataProvider \Yiisoft\Db\Mysql\Tests\Provider\CommandProvider::rawSql
      *

--- a/tests/CommandTest.php
+++ b/tests/CommandTest.php
@@ -98,7 +98,7 @@ final class CommandTest extends CommonCommandTest
         $command = $this->getConnection()->createCommand();
 
         $this->expectException(NotSupportedException::class);
-        $this->expectExceptionMessage('SQLite doesn\'t support cascade drop table.');
+        $this->expectExceptionMessage('MySQL doesn\'t support cascade drop table.');
         $command->dropTable('{{table}}', cascade: true);
     }
 

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -767,7 +767,7 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
             $qb = $this->getConnection()->getQueryBuilder();
 
             $this->expectException(NotSupportedException::class);
-            $this->expectExceptionMessage('SQLite doesn\'t support cascade drop table.');
+            $this->expectExceptionMessage('MySQL doesn\'t support cascade drop table.');
 
             $ifExists === null
                 ? $qb->dropTable('customer', cascade: true)

--- a/tests/QueryBuilderTest.php
+++ b/tests/QueryBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yiisoft\Db\Mysql\Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use Throwable;
 use Yiisoft\Db\Command\Param;
@@ -757,5 +758,24 @@ final class QueryBuilderTest extends CommonQueryBuilderTest
     public function testBuildColumnDefinition(string $expected, ColumnInterface|string $column): void
     {
         parent::testBuildColumnDefinition($expected, $column);
+    }
+
+    #[DataProvider('dataDropTable')]
+    public function testDropTable(string $expected, ?bool $ifExists, ?bool $cascade): void
+    {
+        if ($cascade) {
+            $qb = $this->getConnection()->getQueryBuilder();
+
+            $this->expectException(NotSupportedException::class);
+            $this->expectExceptionMessage('SQLite doesn\'t support cascade drop table.');
+
+            $ifExists === null
+                ? $qb->dropTable('customer', cascade: true)
+                : $qb->dropTable('customer', ifExists: $ifExists, cascade: true);
+
+            return;
+        }
+
+        parent::testDropTable($expected, $ifExists, $cascade);
     }
 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ✔️

See https://github.com/yiisoft/db/pull/880

