### PR TITLE
Call `DbArrayHelper::arrange()` instead of `DbArrayHelper::index()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - New #383: Add `caseSensitive` option to like condition (@vjik)
 - Enh #386: Remove `getCacheKey()` and `getCacheTag()` methods from `Schema` class (@Tigrov)
 - Bug #388: Set empty `comment` and `extra` properties to `null` when loading table columns (@Tigrov)
+- Enh #389: Use `DbArrayHelper::arrange()` instead of `DbArrayHelper::index()` method (@Tigrov)
 
 ## 1.2.0 March 21, 2024
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -483,7 +483,7 @@ final class Schema extends AbstractPdoSchema
 
         /** @psalm-var array[][] $constraints */
         $constraints = array_map(array_change_key_case(...), $constraints);
-        $constraints = DbArrayHelper::index($constraints, null, ['type', 'name']);
+        $constraints = DbArrayHelper::arrange($constraints, ['type', 'name']);
 
         $result = [
             self::PRIMARY_KEY => null,
@@ -598,7 +598,7 @@ final class Schema extends AbstractPdoSchema
 
         /** @psalm-var array[] $indexes */
         $indexes = array_map(array_change_key_case(...), $indexes);
-        $indexes = DbArrayHelper::index($indexes, null, ['name']);
+        $indexes = DbArrayHelper::arrange($indexes, ['name']);
         $result = [];
 
         /**


### PR DESCRIPTION
Related PR
- https://github.com/yiisoft/db/pull/954

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️/❌
| Breaks BC?    | ✔️/❌
| Fixed issues  | 
