### PR TITLE
Fix SQL injection in Schema::findViewNames()

### DIFF
--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -70,6 +70,6 @@ jobs:
 
       - name: Run infection.
         run: |
-          vendor/bin/infection --threads=2 --ignore-msi-with-no-mutations
+          vendor/bin/infection --threads=1 --ignore-msi-with-no-mutations
         env:
           STRYKER_DASHBOARD_API_KEY: ${{ secrets.STRYKER_DASHBOARD_API_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Enh #460: Remove unnecessary files from Composer package (@mspirkov)
 - Enh #461: Add `ext-pdo_mysql` to `require` section of `composer.json` (@Tigrov)
 - Enh #462: Remove `ext-ctype` from `require` section of `composer.json` (@Tigrov)
+- Bug #463: Fix SQL injection in Schema::findViewNames() (@darkspock)
 
 ## 2.0.0 December 05, 2025
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Enh #460: Remove unnecessary files from Composer package (@mspirkov)
 - Enh #461: Add `ext-pdo_mysql` to `require` section of `composer.json` (@Tigrov)
 - Enh #462: Remove `ext-ctype` from `require` section of `composer.json` (@Tigrov)
-- Bug #463: Fix SQL injection in Schema::findViewNames() (@darkspock)
+- Bug #463: Fix SQL injection in `Schema::findViewNames()` (@darkspock, @vjik)
 
 ## 2.0.0 December 05, 2025
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -187,16 +187,17 @@ final class Schema extends AbstractPdoSchema
 
     protected function findViewNames(string $schema = ''): array
     {
-        $sql = match ($schema) {
-            '' => <<<SQL
+        if ($schema === '') {
+            $sql = <<<SQL
             SELECT table_name FROM information_schema.tables WHERE table_type = 'VIEW' AND table_schema != 'sys' order by table_name
-            SQL,
-            default => <<<SQL
+            SQL;
+            $params = [];
+        } else {
+            $sql = <<<SQL
             SELECT table_name FROM information_schema.tables WHERE table_type = 'VIEW' AND table_schema = :schemaName order by table_name
-            SQL,
-        };
-
-        $params = $schema !== '' ? [':schemaName' => $schema] : [];
+            SQL;
+            $params = [':schemaName' => $schema];
+        }
 
         /** @var string[] */
         return $this->db->createCommand($sql, $params)->queryColumn();

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -192,12 +192,14 @@ final class Schema extends AbstractPdoSchema
             SELECT table_name FROM information_schema.tables WHERE table_type = 'VIEW' AND table_schema != 'sys' order by table_name
             SQL,
             default => <<<SQL
-            SELECT table_name FROM information_schema.tables WHERE table_type = 'VIEW' AND table_schema = '$schema' order by table_name
+            SELECT table_name FROM information_schema.tables WHERE table_type = 'VIEW' AND table_schema = :schemaName order by table_name
             SQL,
         };
 
+        $params = $schema !== '' ? [':schemaName' => $schema] : [];
+
         /** @var string[] */
-        return $this->db->createCommand($sql)->queryColumn();
+        return $this->db->createCommand($sql, $params)->queryColumn();
     }
 
     /**

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -264,8 +264,43 @@ final class SchemaTest extends CommonSchemaTest
         };
 
         $this->assertSame($viewExpected, $views);
+    }
 
-        $db->close();
+    public function testGetViewNamesWithSchema(): void
+    {
+        $db = TestConnection::create();
+
+        $schema1 = 'test_get_view_names_with_schema1';
+        $schema2 = 'test_get_view_names_with_schema2';
+
+        try {
+            $db->createCommand("CREATE DATABASE IF NOT EXISTS `$schema1`")->execute();
+            $db->createCommand("CREATE DATABASE IF NOT EXISTS `$schema2`")->execute();
+
+            $db->createCommand("CREATE OR REPLACE VIEW `$schema1`.`view_a` AS SELECT 1")->execute();
+            $db->createCommand("CREATE OR REPLACE VIEW `$schema1`.`view_b` AS SELECT 1")->execute();
+            $db->createCommand("CREATE OR REPLACE VIEW `$schema2`.`view_c` AS SELECT 1")->execute();
+
+            $schema = $db->getSchema();
+
+            $this->assertSame(['view_a', 'view_b'], $schema->getViewNames($schema1));
+            $this->assertSame(['view_c'], $schema->getViewNames($schema2));
+        } finally {
+            $db->createCommand("DROP DATABASE IF EXISTS `$schema1`")->execute();
+            $db->createCommand("DROP DATABASE IF EXISTS `$schema2`")->execute();
+            $db->close();
+        }
+    }
+
+    public function testGetViewNamesSqlInjection(): void
+    {
+        $db = $this->getSharedConnection();
+        $this->loadFixture();
+
+        $schema = $db->getSchema();
+        $views = $schema->getViewNames("' OR ''='");
+
+        $this->assertSame([], $views);
     }
 
     #[DataProviderExternal(SchemaProvider::class, 'constraints')]


### PR DESCRIPTION
## Summary

`Schema::findViewNames()` interpolates the `$schema` parameter directly into a SQL heredoc string:

```php
SELECT table_name FROM information_schema.tables
WHERE table_type = 'VIEW' AND table_schema = '$schema'
order by table_name
```

This is a SQL injection risk. While `$schema` typically comes from configuration rather than user input, this is inconsistent with the rest of the codebase where all other methods in this file use either parameterized queries or proper quoting:

- `findTableComment()` (line 164): uses `:schemaName` bound parameter
- `findTableNames()` (line 181): uses `quoteSimpleTableName()`
- `loadTableConstraints()`, `loadTableIndexes()`, etc.: all use `:schemaName`

### Fix

Replace direct string interpolation with a `:schemaName` bound parameter, consistent with `findTableComment()` and other methods in the same file.

### Before
```php
default => <<<SQL
SELECT table_name FROM information_schema.tables
WHERE table_type = 'VIEW' AND table_schema = '$schema'
order by table_name
SQL,
```

### After
```php
default => <<<SQL
SELECT table_name FROM information_schema.tables
WHERE table_type = 'VIEW' AND table_schema = :schemaName
order by table_name
SQL,
```

## Risk

Very low — this is a direct replacement of string interpolation with parameter binding. The query behavior is identical.