### PR TITLE
Remove tests for schema-wide getters removed in yiisoft/db#1175

### DIFF
--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -159,26 +159,6 @@ final class SchemaTest extends CommonSchemaTest
         $db->close();
     }
 
-    public function testGetSchemaChecks(): void
-    {
-        $this->expectException(NotSupportedException::class);
-        $this->expectExceptionMessage(
-            'Yiisoft\Db\Mysql\Schema::loadTableChecks is not supported by MySQL.',
-        );
-
-        parent::testGetSchemaChecks();
-    }
-
-    public function testGetSchemaDefaultValues(): void
-    {
-        $this->expectException(NotSupportedException::class);
-        $this->expectExceptionMessage(
-            'Yiisoft\Db\Mysql\Schema::loadTableDefaultValues is not supported by MySQL.',
-        );
-
-        parent::testGetSchemaDefaultValues();
-    }
-
     public function testGetSchemaNames(): void
     {
         $db = $this->getSharedConnection();


### PR DESCRIPTION
Companion to yiisoft/db#1175, which removes `getSchemaChecks()` and `getSchemaDefaultValues()` from `ConstraintSchemaInterface`.

`tests/SchemaTest.php` overrode both test methods and delegated to `parent::`, so once the parent methods are gone those calls fail with `Call to undefined method Yiisoft\Db\Tests\Common\CommonSchemaTest::testGetSchemaChecks()`. Removing the overrides.

Cannot merge before the core PR.

| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | yiisoft/db#1175
