### PR TITLE
Fix HY093 in loadTableForeignKeys() when prepare emulation is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Enh #461: Add `ext-pdo_mysql` to `require` section of `composer.json` (@Tigrov)
 - Enh #462: Remove `ext-ctype` from `require` section of `composer.json` (@Tigrov)
 - Bug #463: Fix SQL injection in `Schema::findViewNames()` (@darkspock, @vjik)
+- Bug #458: Fix "SQLSTATE[HY093]: Invalid parameter number" in `Schema::loadTableForeignKeys()` when
+  `PDO::ATTR_EMULATE_PREPARES` is disabled (@KalimeroMK)
 
 ## 2.0.0 December 05, 2025
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -311,12 +311,17 @@ final class Schema extends AbstractPdoSchema
 
     protected function loadTableForeignKeys(string $tableName): array
     {
+        /**
+         * The schema name is bound twice under different placeholders on purpose. With
+         * `PDO::ATTR_EMULATE_PREPARES` disabled, reusing one named placeholder makes the driver bind a single
+         * value for two markers, and MySQL rejects the statement with "SQLSTATE[HY093]: Invalid parameter number".
+         */
         $sql = <<<SQL
         SELECT
             `kcu`.`CONSTRAINT_NAME` AS `name`,
             `kcu`.`COLUMN_NAME` AS `column_name`,
         CASE
-            WHEN :schemaName IS NULL AND `kcu`.`REFERENCED_TABLE_SCHEMA` = DATABASE() THEN ''
+            WHEN :schemaName1 IS NULL AND `kcu`.`REFERENCED_TABLE_SCHEMA` = DATABASE() THEN ''
         ELSE `kcu`.`REFERENCED_TABLE_SCHEMA`
         END AS `foreign_table_schema`,
             `kcu`.`REFERENCED_TABLE_NAME` AS `foreign_table_name`,
@@ -330,14 +335,16 @@ final class Schema extends AbstractPdoSchema
             `rc`.`TABLE_NAME` = `kcu`.`TABLE_NAME` AND
             `rc`.`CONSTRAINT_NAME` = `kcu`.`CONSTRAINT_NAME`
         WHERE
-            `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName, DATABASE()) AND
+            `kcu`.`TABLE_SCHEMA` = COALESCE(:schemaName2, DATABASE()) AND
             `kcu`.`TABLE_NAME` = :tableName
         ORDER BY `position` ASC
         SQL;
 
         $nameParts = $this->db->getQuoter()->getTableNameParts($tableName);
+        $schemaName = $nameParts['schemaName'] ?? null;
         $foreignKeys = $this->db->createCommand($sql, [
-            ':schemaName' => $nameParts['schemaName'] ?? null,
+            ':schemaName1' => $schemaName,
+            ':schemaName2' => $schemaName,
             ':tableName' => $nameParts['name'],
         ])->queryAll();
 

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -311,11 +311,6 @@ final class Schema extends AbstractPdoSchema
 
     protected function loadTableForeignKeys(string $tableName): array
     {
-        /**
-         * The schema name is bound twice under different placeholders on purpose. With
-         * `PDO::ATTR_EMULATE_PREPARES` disabled, reusing one named placeholder makes the driver bind a single
-         * value for two markers, and MySQL rejects the statement with "SQLSTATE[HY093]: Invalid parameter number".
-         */
         $sql = <<<SQL
         SELECT
             `kcu`.`CONSTRAINT_NAME` AS `name`,

--- a/tests/SchemaTest.php
+++ b/tests/SchemaTest.php
@@ -200,6 +200,26 @@ final class SchemaTest extends CommonSchemaTest
         parent::testGetTableChecks();
     }
 
+    /**
+     * @link https://github.com/yiisoft/db-mysql/issues/458
+     */
+    public function testGetTableForeignKeysWithoutEmulatedPrepares(): void
+    {
+        $this->loadFixture();
+
+        $db = $this->createConnection();
+        $db->setEmulatePrepare(false);
+        $db->open();
+
+        $foreignKeys = $db->getSchema()->getTableForeignKeys('order_item');
+
+        $this->assertArrayHasKey('FK_order_item_order_id', $foreignKeys);
+        $this->assertSame('order', $foreignKeys['FK_order_item_order_id']->foreignTableName);
+        $this->assertSame(['id'], $foreignKeys['FK_order_item_order_id']->foreignColumnNames);
+
+        $db->close();
+    }
+
     public function testGetTableNamesWithSchema(): void
     {
         $db = $this->getSharedConnection();


### PR DESCRIPTION
`Schema::loadTableForeignKeys()` used `:schemaName` twice in one statement, once in the `CASE` expression and once in the `WHERE` clause.

@vjik asked on the issue whether PDO allows that. It depends on `PDO::ATTR_EMULATE_PREPARES`, which is why the suite never caught it — with emulation on, PDO rewrites the placeholders client-side, but with it off the statement is prepared natively and each marker needs its own value:

    ATTR_EMULATE_PREPARES = true   ->  OK
    ATTR_EMULATE_PREPARES = false  ->  SQLSTATE[HY093]: Invalid parameter number

Binds the value as `:schemaName1` and `:schemaName2` instead. Added `testGetTableForeignKeysWithoutEmulatedPrepares()`, which opens a connection with `setEmulatePrepare(false)`; it errors with the exception above without the fix.

| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #458
